### PR TITLE
Fix Metamask window.web3 injection deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # VotingdApp
 
 Voting Application for the bloxberg network where members vote on various governance related issues.
+
+# Running
+
+Since Metamask [does not](https://ethereum.stackexchange.com/a/16133/22019) inject into local files you need a simple HTTP server. You can use Python's SimpleHTTPServer with:
+
+```
+python -m SimpleHTTPServer
+```
+
+or follow [instructions here](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server)

--- a/admin/assets/css/app.css
+++ b/admin/assets/css/app.css
@@ -62,3 +62,14 @@ h3 {
 .footer{bottom:0;left:0;height:60px;background-image:url("../images/bg_footer.png");background-size:cover;background-position:center center;color:#fff}@media screen and (max-width:768px){.footer{height:80px}}.footer .container{position:relative}.footer .logo,.footer .socials{transform:translateY(-50%);position:absolute;z-index:1;top:50%}@media screen and (max-width:768px){.footer .logo,.footer .socials{transform:translate(0);top:20px}}.footer .logo{z-index:2;display:inline-block;vertical-align:middle;width:126px;height:24px;background-image:url("../images/logo-white.png");background-position:-37px 0;background-repeat:no-repeat}@media(min--moz-device-pixel-ratio:1.3),(-webkit-min-device-pixel-ratio:1.3),(min-device-pixel-ratio:1.3),(min-resolution:1.3dppx){.footer .logo{background-image:url("../images/logo-white.png");background-size:126px 24px}}
 
 .footer .rights{color:#fff;text-align:center;font-size:12px}
+
+#footercontainer {
+  position: fixed;
+  height: 50px;
+  bottom: 0px;
+  left: 0px;
+  right: 0px;
+  clear: both;
+  margin-bottom: 0px;
+
+}

--- a/admin/assets/js/app.js
+++ b/admin/assets/js/app.js
@@ -10,6 +10,7 @@ var canUserVote;
 var myContractInstance;
 var WAD = 1000000000000000000;
 var modalShow = false;
+// var contract_address = "0xEea584517644eb0B82eAba9B33CFA0ceF7A3F7B2";
 var contract_address = "0x19e51afd3efa98a6e4b82d3834de174d7a33f9b5";
 var contract_abi = [
   {
@@ -500,7 +501,7 @@ var contract_abi = [
 // Initialize
 function initializeContract() {
   console.log(contract_address);
-  myContractInstance = web3.eth.contract(contract_abi).at(contract_address);
+  myContractInstance = new window.web3.eth.Contract(contract_abi, contract_address);
   $("#cf_address").html(contract_address);
   $("#cb_address").html(account);
   refreshDataNew();
@@ -508,98 +509,107 @@ function initializeContract() {
 
 
 function refreshDataNew() {
-  getDataPromise(myContractInstance.numProposals).then(
-    function(numProposals) {
-      numTotalProposals = numProposals.toNumber();
-      console.log("numProposals = " + numProposals.toNumber());
+  getDataPromise(myContractInstance.methods.numProposals).then(
+    function (numProposals) {
+      numTotalProposals = parseInt(numProposals);
+      console.log("numProposals = " + parseInt(numProposals));
       //$("#numProposals").html(numProposals.toNumber());
-      return getDataPromise(myContractInstance.numEndedProposals);
+      return getDataPromise(myContractInstance.methods.numEndedProposals);
     }).then(
-    function(numEndedProposals) {
-      console.log("numEndedProposals = " + numEndedProposals.toNumber());
-      //$("#numEndedProposals").html(numEndedProposals.toNumber());
-      totalEndedProposals = numEndedProposals.toNumber();
-      $("#numOpenProposals").html(numTotalProposals - totalEndedProposals);
-      return getDataPromise(myContractInstance.numVoters);
-    }).then(
-    function(numVoters) {
-      console.log("numVoters = " + numVoters.toNumber());
-      $("#numVoters").html(numVoters.toNumber());
-      return getDataPromiseWithArgs(myContractInstance.getVoterDetail, account);
-    }).then(
-    function(result) {
-      console.log("canUserVote = " + result[0]);
-      canUserVote=result[0];
-      if (canUserVote) {
-        $("#canUserVote").html("Yes");
+      function (numEndedProposals) {
+        console.log("numEndedProposals = " + parseInt(numEndedProposals));
+        //$("#numEndedProposals").html(numEndedProposals.toNumber());
+        totalEndedProposals = parseInt(numEndedProposals);
+        $("#numOpenProposals").html(numTotalProposals - totalEndedProposals);
+        return getDataPromise(myContractInstance.methods.numVoters);
+      }).then(
+        function (numVoters) {
+          console.log("numVoters = " + parseInt(numVoters));
+          $("#numVoters").html(parseInt(numVoters));
+          return getDataPromiseWithArgs(myContractInstance.methods.getVoterDetail, account);
+        }).then(
+          function (result) {
+            let { result: canUserVote, weight } = result;
+            console.log("canUserVote = " + canUserVote);
+            canUserVote = result[0];
+            if (canUserVote) {
+              $("#canUserVote").html("Yes");
+            } else {
+              $("#canUserVote").html("No");
+            }
+            $("#votingWeight").html(weight);
+
+            return getDataPromise(myContractInstance.methods.chairperson);
+          }).then(
+            function (chairperson) {
+              console.log("chairperson = " + chairperson);
+              chairpersonAddress = chairperson;
+              $("#chairperson").html(chairperson);
+              if (chairpersonAddress == account) {
+                $("#footercontainer").html("<footer class=\"footer\"><div class=\"container\"><p class=\"rights\"><br>2021 Bloxberg Network. All rights reserved.</p><a class=\"logo\" href='/'></a><div class=\"socials\"></div></div></footer>");
+              } else {
+                $("#admincontainer").hide();
+                $("#statuscontainer").html("<h4 style='margin-bottom: 80px'>You are not authorized to perform admin actions</h4>");
+                $("#footercontainer").html("<footer class=\"footer\" style=\"position:absolute;\"><div class=\"container\"><p class=\"rights\"><br>2021 Bloxberg Network. All rights reserved.</p><a class=\"logo\" href='/'></a><div class=\"socials\"></div></div></footer>");
+              }
+
+            });
+}
+
+
+
+function getDataPromise(method) {
+  return new Promise(function (resolve, reject) {
+    method().call({ from: account }, function (error, result) {
+      console.log('Returned!')
+      if (!error) {
+        resolve(result);
       } else {
-        $("#canUserVote").html("No");
-      }
-      $("#votingWeight").html(result[1].toNumber());
-
-      return getDataPromise(myContractInstance.chairperson);
-    }).then(
-    function(chairperson) {
-      console.log("chairperson = " + chairperson);
-      chairpersonAddress = chairperson;
-      $("#chairperson").html(chairperson);
-      if(chairpersonAddress==account){
-      $("#footercontainer").html("<footer class=\"footer\"><div class=\"container\"><p class=\"rights\"><br>2019 Bloxberg Network. All rights reserved.</p><a class=\"logo\" href='/'></a><div class=\"socials\"></div></div></footer>");  
-      }else{
-        $("#admincontainer").hide();
-        $("#statuscontainer").html("<h4>You are not authorized to perform admin actions</h4>");
-        $("#footercontainer").html("<footer class=\"footer\" style=\"position:absolute;\"><div class=\"container\"><p class=\"rights\"><br>2019 Bloxberg Network. All rights reserved.</p><a class=\"logo\" href='/'></a><div class=\"socials\"></div></div></footer>");
-      }
-      
-    });
-}
-
-
-
-function getDataPromise(varname) {
-  return new Promise(function(resolve, reject) {
-    varname.call(function(error, result) {
-      if (!error) {
-        resolve(result);
+        reject(error)
       }
     })
   })
 }
 
-function getDataPromiseWithArgs(varname, args) {
-  return new Promise(function(resolve, reject) {
-    varname.call(args, function(error, result) {
+async function getDataPromiseWithArgs(method, args) {
+  return await new Promise(function (resolve, reject) {
+    method(args).call({ from: account }, function (error, result) {
+      console.log('Called method with 1 arg')
       if (!error) {
         resolve(result);
+      } else {
+        reject(error)
       }
     })
   })
 }
 
-function getDataPromiseWithTwoArgs(varname, arg1, arg2) {
-  return new Promise(function(resolve, reject) {
-    varname.call(arg1, arg2, function(error, result) {
+function getDataPromiseWithTwoArgs(method, arg1, arg2) {
+  return new Promise(function (resolve, reject) {
+    method(arg1, arg2).call({ from: account }, function (error, result) {
+      console.log('Called method with 2 args')
       if (!error) {
         resolve(result);
+      } else {
+        reject(error)
       }
     })
   })
 }
 
 function getBalancePromise(addr) {
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
 
-    web3.eth.getBalance(addr, function(error, result) {
+    window.web3.eth.getBalance(addr, function (error, result) {
       if (!error) {
         resolve(result);
       }
     })
-
   })
 }
 
-function getDataNum(varname, divtag) {
-  varname.call(function(error, result) {
+function getDataNum(method, divtag) {
+  method().call({ from: account }, function (error, result) {
     if (!error) {
       $(divtag).html(result.toNumber());
     } else {
@@ -608,8 +618,8 @@ function getDataNum(varname, divtag) {
   })
 }
 
-function getDataStr(varname, divtag) {
-  varname.call(function(error, result) {
+function getDataStr(method, divtag) {
+  method().call({ from: account }, function (error, result) {
     if (!error) {
       $(divtag).html(result);
     } else {
@@ -623,52 +633,52 @@ function setStatus(message) {
 }
 
 
-function giveRightToVoteMember() {  
+function giveRightToVoteMember() {
   var address = $("#giveRightToVoteAddress").val();
-  myContractInstance.giveRightToVoteMember(address, function(error, result) {
-    if (!error) {
-      getTransactionReceiptMined(result).then(
-        function(receipt) {
+  myContractInstance.methods.giveRightToVoteMember(address).send({ from: account })
+    .then(tx => {
+      getTransactionReceiptMined(tx.transactionHash).then(
+        function (receipt) {
           console.log(receipt.transactionHash);
           $("#myModal").modal();
           $("#myModalTitle").html("Transaction Successful");
           $("#myModalText").html("Your transaction to give rights to vote to address " + address + " has been processed successfully. Transaction hash: " + receipt.transactionHash);
         });
-    }
-  });
+    })
+    .catch(console.error)
 }
 
-function revokeRightToVote() {  
+function revokeRightToVote() {
   var address = $("#revokeRightToVoteAddress").val();
-  myContractInstance.revokeRightToVote(address, function(error, result) {
-    if (!error) {
-      getTransactionReceiptMined(result).then(
-        function(receipt) {
+  myContractInstance.methods.revokeRightToVote(address).send({ from: account })
+    .then(tx => {
+      getTransactionReceiptMined(tx.transactionHash).then(
+        function (receipt) {
           console.log(receipt.transactionHash);
           $("#myModal").modal();
           $("#myModalTitle").html("Transaction Successful");
           $("#myModalText").html("Your transaction to revoke rights to vote to address " + address + " has been processed successfully. Transaction hash: " + receipt.transactionHash);
         });
-    }
-  });
+    })
+    .catch(console.error)
 }
 
-function finalizeProposal() {  
+function finalizeProposal() {
   var proposalNumber = $("#proposalNumber").val();
-  myContractInstance.finalizeProposal(proposalNumber, function(error, result) {
-    if (!error) {
-      getTransactionReceiptMined(result).then(
-        function(receipt) {
+  myContractInstance.methods.finalizeProposal(proposalNumber).send({ from: account })
+    .then(tx => {
+      getTransactionReceiptMined(tx.transactionHash).then(
+        function (receipt) {
           console.log(receipt.transactionHash);
           $("#myModal").modal();
           $("#myModalTitle").html("Transaction Successful");
           $("#myModalText").html("Your transaction to finalize Proposal #" + proposalNumber + " has been processed successfully. Transaction hash: " + receipt.transactionHash);
         });
-    }
-  });
+    })
+    .catch(console.error)
 }
 
-function createProposal() {  
+function createProposal() {
   var proposalName = $("#proposalName").val();
   var batchNumber = $("#batchNumber").val();
   var optionName1 = $("#optionName1").val();
@@ -677,17 +687,29 @@ function createProposal() {
   var optionName4 = $("#optionName4").val();
   var optionName5 = $("#optionName5").val();
   var votingTime = $("#votingTime").val();
-  var error=false;
+  var error = false;
 
-  if(optionName1.length>32 || optionName2.length>32 || optionName3.length>32 || optionName4.length>32 || optionName5.length>32 ){
-    error=true;
+  if (!proposalName) {
+    error = true;
+    $("#myModalNoRefresh").modal();
+    $("#myModalTitle1").html("No proposal name");
+    $("#myModalText1").html("Please provide a name for your proposal");
+  }
+  if (!batchNumber) {
+    error = true;
+    $("#myModalNoRefresh").modal();
+    $("#myModalTitle1").html("No batch number");
+    $("#myModalText1").html("Please a batch number");
+  }
+  if (optionName1.length > 32 || optionName2.length > 32 || optionName3.length > 32 || optionName4.length > 32 || optionName5.length > 32) {
+    error = true;
     $("#myModalNoRefresh").modal();
     $("#myModalTitle1").html("Proposal Title or Options Too Long");
     $("#myModalText1").html("Please provide shorter proposal title or option names (less than 32 characters)");
   }
 
-  if(votingTime<=0){
-    error=true;
+  if (votingTime <= 0) {
+    error = true;
     $("#myModalNoRefresh").modal();
     $("#myModalTitle1").html("Invalid Voting Time");
     $("#myModalText1").html("Please enter a valid voting time in seconds");
@@ -695,68 +717,53 @@ function createProposal() {
 
   // var proposalNameHex = web3.fromAscii(proposalName);
 
-  var optionNamesHex = [web3.fromAscii(optionName1),web3.fromAscii(optionName2)];
-  if (optionName3.length>0){
-    optionNamesHex.push(web3.fromAscii(optionName3));
+  var optionNamesHex = [window.web3.utils.asciiToHex(optionName1), window.web3.utils.asciiToHex(optionName2)];
+  if (optionName3.length > 0) {
+    optionNamesHex.push(window.web3.utils.asciiToHex(optionName3));
   }
-  if (optionName4.length>0){
-    optionNamesHex.push(web3.fromAscii(optionName4));
+  if (optionName4.length > 0) {
+    optionNamesHex.push(window.web3.utils.asciiToHex(optionName4));
   }
-  if (optionName5.length>0){
-    optionNamesHex.push(web3.fromAscii(optionName5));
+  if (optionName5.length > 0) {
+    optionNamesHex.push(window.web3.utils.asciiToHex(optionName5));
   }
 
   // console.log("proposalNameHex = " + proposalNameHex);
-  console.log("optionNamesHex = " + optionNamesHex);
+  console.log("optionNamesHex");
+  console.log(optionNamesHex)
   console.log("votingTime = " + votingTime);
 
-  if(!error){
-    myContractInstance.createProposal(proposalName, optionNamesHex, votingTime, batchNumber, function(error, result) {
-      if (!error) {
-        getTransactionReceiptMined(result).then(
-          function(receipt) {
+  if (!error) {
+    myContractInstance.methods.createProposal(proposalName, optionNamesHex, votingTime, batchNumber).send({ from: account })
+      .then(tx => {
+        console.log(tx)
+        getTransactionReceiptMined(tx.transactionHash).then(
+          function (receipt) {
             console.log(receipt.transactionHash);
             $("#myModal").modal();
             $("#myModalTitle").html("Transaction Successful");
             $("#myModalText").html("Your transaction to create a new proposal titled \"" + proposalName + "\" has been processed successfully. Transaction hash: " + receipt.transactionHash);
           });
-      }
-    });
+      })
+      .catch(console.error)
   }
 }
 
-var loadPage = () => {
-  setTimeout(() => {
-    if (!window.web3 || !window.web3.eth.accounts[0]) {
-      $("#votingcontractcontainer").hide();
-      $("#admincontainer").hide();
-      $("#footercontainer").html("<footer class=\"footer\" style=\"position:absolute;\"><div class=\"container\"><p class=\"rights\"><br>2019 Bloxberg Network. All rights reserved.</p><a class=\"logo\" href='/'></a><div class=\"socials\"></div></div></footer>");
-      $("#status").html(`
-       <div>
-         <div class="pane before-error">
-           <h2>Could not connect to Bloxberg</h2>
-           <p>
-
-             Consider installing <a href=https://metamask.io>MetaMask</a> or another Ethereum client.
-
-             If you are using MetaMask, you may need to unlock your account and connect to the Bloxberg network using custom RPC endpoint https://bloxberg.org/eth/. You can also try disabling and re-enabling
-             the MetaMask plugin by going to <a href=chrome://extensions>chrome://extensions</a>.
-           </p>
-
-           <p>Please reload this page and try again.</p>
-         </div>
-       </div>
-     `);
+var loadPage = async () => {
+  setTimeout(async () => {
+    const accounts = await ethereum.request({ method: 'eth_accounts' });
+    if (!accounts[0]) {
+      setErrorMessage();
     } else {
       //initializeContract();
-      account = web3.eth.accounts[0];
+      account = window.web3.utils.toChecksumAddress(accounts[0]);
       console.log(account);
       initializeContract();
 
-      web3.eth.getBalance(account, function(error, result) {
+      window.web3.eth.getBalance(account, function (error, result) {
         if (!error) {
           console.log(result);
-          $("#cb_balance").html(web3.fromWei(result, "ether").toFixed(5));
+          $("#cb_balance").html(parseInt(window.web3.utils.fromWei(result, "ether")).toFixed(5));
 
         } else {
           console.error(error);
@@ -771,24 +778,31 @@ var loadPage = () => {
 if (document.readyState !== 'complete') {
   // Document has not finished loaded yet, load the page when it is complete
   window.addEventListener('load', async () => {
-    await ethereum.enable();
-    loadPage();
+    console.log('Page loaded')
+    if (window.ethereum) {
+      console.log('window.ethereum')
+      await ethereum.enable();
+      window.web3 = new Web3(window.ethereum);
+      loadPage();
+    } else {
+      console.log('none')
+      // Document has finished loaded, load the page
+      setErrorMessage();
+    }
   })
-} else {
-  // Document has finished loaded, load the page
-  loadPage();
 }
+
 
 function getTransactionReceiptMined(txHash, interval) {
   var transactionReceiptAsync;
   interval = interval ? interval : 500;
-  transactionReceiptAsync = function(txHash, resolve, reject) {
-    web3.eth.getTransactionReceipt(txHash, (error, receipt) => {
+  transactionReceiptAsync = function (txHash, resolve, reject) {
+    window.web3.eth.getTransactionReceipt(txHash, (error, receipt) => {
       if (error) {
         reject(error);
       } else {
         if (receipt == null) {
-          setTimeout(function() {
+          setTimeout(function () {
             transactionReceiptAsync(txHash, resolve, reject);
           }, interval);
         } else {
@@ -800,12 +814,12 @@ function getTransactionReceiptMined(txHash, interval) {
 
   if (Array.isArray(txHash)) {
     var promises = [];
-    txHash.forEach(function(oneTxHash) {
-      promises.push(web3.eth.getTransactionReceiptMined(oneTxHash, interval));
+    txHash.forEach(function (oneTxHash) {
+      promises.push(window.web3.eth.getTransactionReceiptMined(oneTxHash, interval));
     });
     return Promise.all(promises);
   } else {
-    return new Promise(function(resolve, reject) {
+    return new Promise(function (resolve, reject) {
       transactionReceiptAsync(txHash, resolve, reject);
     });
   }
@@ -822,4 +836,28 @@ function timeConverter(UNIX_timestamp) {
   var sec = a.getSeconds();
   var time = month + ' ' + date + ', ' + year + ' at ' + hour + ':' + min + ':' + sec;
   return time;
+}
+
+
+function setErrorMessage() {
+  $("#votingcontractcontainer").hide();
+  $("#votingproposalcontainer").hide();
+  $("#closedvotingproposalcontainer").hide();
+  $("#footercontainer").html("<footer class=\"footer\" style=\"position:absolute;\"><div class=\"container\"><p class=\"rights\"><br>2019 Bloxberg Network. All rights reserved.</p><a class=\"logo\" href='/'></a><div class=\"socials\"></div></div></footer>");
+  $("#status").html(`
+	<div>
+		<div class="pane before-error">
+			<h2>Could not connect to Bloxberg</h2>
+			<p>
+
+				Consider installing <a href=https://metamask.io>MetaMask</a> or another Ethereum client.
+
+				If you are using MetaMask, you may need to unlock your account and connect to the Bloxberg network using custom RPC endpoint https://bloxberg.org/eth/. You can also try disabling and re-enabling
+				the MetaMask plugin by going to <a href=chrome://extensions>chrome://extensions</a>.
+			</p>
+
+			<p>Please reload this page and try again.</p>
+		</div>
+	</div>
+`);
 }

--- a/admin/index.html
+++ b/admin/index.html
@@ -171,7 +171,7 @@
   </div>
   <!-- Latest compiled and minified JavaScript -->
   <script src="https://code.jquery.com/jquery-3.0.0-beta1.js"></script>
- <script type="text/javascript" src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js"></script>
-
+  <script type="text/javascript" src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/web3@latest/dist/web3.min.js"></script>
 </body>
 </html>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -5,12 +5,12 @@ var numTotalProposals;
 var totalEndedProposals;
 var htmlstr = "";
 var closedhtmlstr = ""
-
 //var proposalNumber;
 var canUserVote;
 var myContractInstance;
 var WAD = 1000000000000000000;
 var modalShow = false;
+// var contract_address = "0xEea584517644eb0B82eAba9B33CFA0ceF7A3F7B2";
 var contract_address = "0x19e51afd3efa98a6e4b82d3834de174d7a33f9b5";
 var contract_abi = [
 	{
@@ -500,106 +500,104 @@ var contract_abi = [
 
 // Initialize
 function initializeContract() {
-  console.log(contract_address);
-  myContractInstance = web3.eth.contract(contract_abi).at(contract_address);
-  $("#cf_address").html(contract_address);
-  $("#cb_address").html(account);
-  refreshDataNew();
+	console.log(contract_address);
+	myContractInstance = new window.web3.eth.Contract(contract_abi, contract_address);
+	$("#cf_address").html(contract_address);
+	$("#cb_address").html(account);
+	refreshDataNew();
 }
 
 
 function refreshDataNew() {
-  getDataPromise(myContractInstance.numProposals).then(
-    function(numProposals) {
-      numTotalProposals = numProposals.toNumber();
-      console.log("numProposals = " + numProposals.toNumber());
-      //$("#numProposals").html(numProposals.toNumber());
-      return getDataPromise(myContractInstance.numEndedProposals);
-    }).then(
-    function(numEndedProposals) {
-      console.log("numEndedProposals = " + numEndedProposals.toNumber());
-      //$("#numEndedProposals").html(numEndedProposals.toNumber());
-      totalEndedProposals = numEndedProposals.toNumber();
-      $("#numOpenProposals").html(numTotalProposals - totalEndedProposals);
-      return getDataPromise(myContractInstance.numVoters);
-    }).then(
-    function(numVoters) {
-      console.log("numVoters = " + numVoters.toNumber());
-      $("#numVoters").html(numVoters.toNumber());
-      return getDataPromiseWithArgs(myContractInstance.getVoterDetail, account);
-    }).then(
-    function(result) {
-      console.log("canUserVote = " + result[0]);
-      canUserVote=result[0];
-      if (canUserVote) {
-        $("#canUserVote").html("Yes");
-      } else {
-        $("#canUserVote").html("No");
-      }
-      $("#votingWeight").html(result[1].toNumber());
+	console.log('Refreshing data')
+	getDataPromise(myContractInstance.methods.numProposals).then(
+		function (numProposals) {
+			numTotalProposals = parseInt(numProposals);
+			console.log("numProposals = " + parseInt(numProposals));
+			//$("#numProposals").html(numProposals.toNumber());
+			return getDataPromise(myContractInstance.methods.numEndedProposals);
+		}).then(
+			function (numEndedProposals) {
+				console.log("numEndedProposals = " + parseInt(numEndedProposals));
+				//$("#numEndedProposals").html(numEndedProposals.toNumber());
+				totalEndedProposals = parseInt(numEndedProposals);
+				$("#numOpenProposals").html(numTotalProposals - totalEndedProposals);
+				return getDataPromise(myContractInstance.methods.numVoters);
+			})
+		.then(
+			function (numVoters) {
+				console.log("numVoters = " + parseInt(numVoters));
+				$("#numVoters").html(parseInt(numVoters));
+				return getDataPromiseWithArgs(myContractInstance.methods.getVoterDetail, account);
+			})
+		.then(
+			function (result) {
+				console.log("canUserVote = " + result[0]);
+				console.log('Voting weight: ' + result[1])
+				canUserVote = result[0];
+				if (canUserVote) {
+					$("#canUserVote").html("Yes");
+				} else {
+					$("#canUserVote").html("No");
+				}
+				$("#votingWeight").html(result[1]);
 
-				return getDataPromise(myContractInstance.chairperson);
-    }).then(
-    function(chairperson) {
-      console.log("chairperson = " + chairperson);
-      $("#chairperson").html(chairperson);
-      if(canUserVote){
-				updateProposalsList();
-				updateClosedProposalsList();
-        $("#footercontainer").html("<footer class=\"footer\"><div class=\"container\"><p class=\"rights\"><br>2019 Bloxberg Network. All rights reserved.</p><a class=\"logo\" href='/'></a><div class=\"socials\"></div></div></footer>");
-      }else{
-        $("#openPropsalsContainer").html("<h4>You are not authorized to vote</h4>");
-        $("#footercontainer").html("<footer class=\"footer\" style=\"position:absolute;\"><div class=\"container\"><p class=\"rights\"><br>2019 Bloxberg Network. All rights reserved.</p><a class=\"logo\" href='/'></a><div class=\"socials\"></div></div></footer>");
-      }      
-    });
+				return getDataPromise(myContractInstance.methods.chairperson);
+			})
+		.then(
+			function (chairperson) {
+				console.log("chairperson = " + chairperson);
+				$("#chairperson").html(chairperson);
+				if (canUserVote) {
+					updateProposalsList();
+					updateClosedProposalsList();
+					$("#footercontainer").html("<footer class=\"footer\"><div class=\"container\"><p class=\"rights\"><br>2021 Bloxberg Network. All rights reserved.</p><a class=\"logo\" href='/'></a><div class=\"socials\"></div></div></footer>");
+				} else {
+					$("#openPropsalsContainer").html("<h4>You are not authorized to vote</h4>");
+					$("#footercontainer").html("<footer class=\"footer\" style=\"position:absolute;\"><div class=\"container\"><p class=\"rights\"><br>2021 Bloxberg Network. All rights reserved.</p><a class=\"logo\" href='/'></a><div class=\"socials\"></div></div></footer>");
+				}
+			})
+		.catch(err => {
+			console.log(err);
+		})
 }
 
 function updateProposalsList() {
-  console.log("numTotalProposals = " + numTotalProposals);
-  for (i = 1; i <= numTotalProposals; i++) {
+	console.log("numTotalProposals = " + numTotalProposals);
+	for (i = 1; i <= numTotalProposals; i++) {
 		getProposalDetail(i);
-		
-  }
+	}
 }
 
 
 
 async function getProposalDetail(proposalNumber) {
-  getDataPromiseWithTwoArgs(myContractInstance.getProposalDetailsForVoter, proposalNumber, account).then(
-    async function(result) {
-			var timeEnd = await getDataPromiseWithArgs(myContractInstance.proposals, proposalNumber).then(
-				 function (result) {
-					proposalName = result[0]
-					timeStart = timeConverter(result[1]['c'][0])
-					timeEnd = result[1]['c'][0] + result[2]['c'][0]
-					timeEnd = timeConverter(timeEnd)
-					return timeEnd
-				})
-      proposalName = result[0];
-      numOptions = result[1];
-      if (numOptions == 0) {
-        //htmlstr+="<h4 style=\"padding-top: 20px; color:#000\">Proposal #"+proposalNumber+": Already voted</h4><br>";
-      } else {
-        htmlstr += "<h4 style=\"padding-top: 20px; color:#000\">Proposal #" + proposalNumber + ": " + proposalName + "</h4><br>";
+	console.log('Getting details for proposal number ' + proposalNumber);
+	let proposalDetails = await getDataPromiseWithArgs(myContractInstance.methods.proposals, proposalNumber);
+	let { isEnded, name, numCastedVotes, numOptions, proposalBatch, votingStart, votingTime, winningProposalOption, winningProposalOptionName } = proposalDetails;
+	console.log(proposalDetails)
 
-        for (j = 0; j < numOptions; j++) {
-          if (j == 0) {
-            htmlstr = htmlstr + "<input type=\"radio\" name=\"proposal" + proposalNumber + "\" value=\"" + j + "\" checked>" + web3.toAscii(result[2][j]) + "<br>";
-          } else {
-            htmlstr = htmlstr + "<input type=\"radio\" name=\"proposal" + proposalNumber + "\" value=\"" + j + "\">" + web3.toAscii(result[2][j]) + "<br>";
-          }
-        }
-				htmlstr = htmlstr + "<br><button class=\"btn btn-primary btn-lg\" onclick=\"vote(" + proposalNumber + ");\">VOTE</button><br><hr>";
-				
-				htmlstr = htmlstr + "<strong>Time Voting Ends: " + timeEnd + "<br></strong>";
-        $("#openPropsalsContainer").html(htmlstr);
-      }
-    }).then(function() {
-    //htmlstr=htmlstr+"<button class=\"btn btn-primary btn-lg\" onclick=\"vote("+proposalNumber+");\">VOTE</button><br><hr>";
-    //$("#openPropsalsContainer").html(htmlstr);
-    //console.log(htmlstr);
-  });
+	let proposalDetailsForVoter = await getDataPromiseWithTwoArgs(myContractInstance.methods.getProposalDetailsForVoter, proposalNumber, account);
+	let { proposalName, numOptions: numOptionsForVoter, optionNames } = proposalDetailsForVoter;
+	console.log(proposalDetailsForVoter)
 
+	let votingEndStr = timeConverter(parseInt(votingStart) + parseInt(votingTime));
+	if (numOptionsForVoter === "0") {
+		htmlstr += "<h4 style=\"padding-top: 20px; color:#000\">Proposal #" + proposalNumber + ": Already voted</h4><br>";
+		// $("#openPropsalsContainer").html(htmlstr);
+	} else {
+		htmlstr += "<h4 style=\"padding-top: 20px; color:#000\">Proposal #" + proposalNumber + ": " + name + "</h4><br>";
+		for (j = 0; j < parseInt(numOptions); j++) {
+			if (j == 0) {
+				htmlstr = htmlstr + "<input type=\"radio\" name=\"proposal" + proposalNumber + "\" value=\"" + j + "\" checked>" + web3.utils.hexToAscii(optionNames[j]) + "<br>";
+			} else {
+				htmlstr = htmlstr + "<input type=\"radio\" name=\"proposal" + proposalNumber + "\" value=\"" + j + "\">" + web3.utils.hexToAscii(optionNames[j]) + "<br>";
+			}
+		}
+		htmlstr = htmlstr + "<br><button class=\"btn btn-primary btn-lg\" onclick=\"vote(" + proposalNumber + ");\">VOTE</button><br><hr>";
+		htmlstr = htmlstr + "<strong>Time Voting Ends: " + votingEndStr + "<br></strong>";
+		$("#openPropsalsContainer").html(htmlstr);
+	}
 }
 
 async function updateClosedProposalsList() {
@@ -609,247 +607,239 @@ async function updateClosedProposalsList() {
 }
 
 async function getClosedProposalDetail(proposalNumber) {
-	await getDataPromiseWithArgs(myContractInstance.proposals, proposalNumber).then(
-		async function (result) {
-			proposalName = result[0]
-			timeStart = timeConverter(result[1]['c'][0])
-			timeEnd = result[1]['c'][0]+ result[2]['c'][0]
-			timeEnd = timeConverter(timeEnd)
-			isProposalFinished = result[6]
-			numCastedVotes = result[5]['c'][0]
-			winningOption = web3.toAscii(result[8])
-			if (isProposalFinished == false) {
-				closedhtmlstr+="<h4 style=\"padding-top: 20px; color:#000\">Proposal #"+proposalNumber+": Voting has not finished</h4><br>";
-				$("#closedPropsalsContainer").html(closedhtmlstr);
+	let result = await getDataPromiseWithArgs(myContractInstance.methods.proposals, proposalNumber);
+	let { isEnded, name, numCastedVotes, numOptions, proposalBatch, votingStart, votingTime, winningProposalOption, winningProposalOptionName } = result;
+	let votingStartStr = timeConverter(parseInt(votingStart));
+	let votingEndStr = timeConverter(parseInt(votingStart) + parseInt(votingTime));
+	winningOptionStr = window.web3.utils.hexToAscii(winningProposalOptionName)
+	if (!isEnded) {
+		closedhtmlstr += "<h4 style=\"padding-top: 20px; color:#000\">Proposal #" + proposalNumber + " \"" + name + "\" " + ": Voting has not finished</h4><br>";
+		$("#closedPropsalsContainer").html(closedhtmlstr);
+	} else {
+		closedhtmlstr += "<h4 style=\"padding-top: 20px; color:#000\">Proposal #" + proposalNumber + ": " + name + "</h4><br>";
+		closedhtmlstr = closedhtmlstr + "Winning Option: " + winningOptionStr + "<br>";
+		closedhtmlstr = closedhtmlstr + "Total Votes Casted: " + numCastedVotes + "<br>";
+		closedhtmlstr = closedhtmlstr + "Time Started: " + votingStartStr + "<br>";
+		closedhtmlstr = closedhtmlstr + "Time Ended: " + votingEndStr + "<br>";
+		$("#closedPropsalsContainer").html(closedhtmlstr);
+	}
+}
+
+function getDataPromise(method) {
+	return new Promise(function (resolve, reject) {
+		method().call({ from: account }, function (error, result) {
+			console.log('Returned!')
+			if (!error) {
+				resolve(result);
 			} else {
-				closedhtmlstr += "<h4 style=\"padding-top: 20px; color:#000\">Proposal #" + proposalNumber + ": " + proposalName + "</h4><br>";
-				closedhtmlstr = closedhtmlstr + "Winning Option: " + winningOption + "<br>";
-				closedhtmlstr = closedhtmlstr + "Total Votes Casted: " + numCastedVotes + "<br>";
-				closedhtmlstr = closedhtmlstr + "Time Started: " + timeStart + "<br>";
-				closedhtmlstr = closedhtmlstr + "Time Ended: " + timeEnd + "<br>";
-				$("#closedPropsalsContainer").html(closedhtmlstr);
+				reject(error)
 			}
-		}).then(function () {
-			//htmlstr=htmlstr+"<button class=\"btn btn-primary btn-lg\" onclick=\"vote("+proposalNumber+");\">VOTE</button><br><hr>";
-			//$("#openPropsalsContainer").html(htmlstr);
-			//console.log(htmlstr);
-		});
+		})
+	})
 }
 
-function getDataPromise(varname) {
-  return new Promise(function(resolve, reject) {
-    varname.call(function(error, result) {
-      if (!error) {
-        resolve(result);
-      }
-    })
-  })
+async function getDataPromiseWithArgs(method, args) {
+	return await new Promise(function (resolve, reject) {
+		method(args).call({ from: account }, function (error, result) {
+			console.log('Called method with 1 arg')
+			if (!error) {
+				resolve(result);
+			} else {
+				reject(error)
+			}
+		})
+	})
 }
 
-async function getDataPromiseWithArgs(varname, args) {
-  return await new Promise(function(resolve, reject) {
-    varname.call(args, function(error, result) {
-      if (!error) {
-        resolve(result);
-      }
-    })
-  })
-}
-
-function getDataPromiseWithTwoArgs(varname, arg1, arg2) {
-  return new Promise(function(resolve, reject) {
-    varname.call(arg1, arg2, function(error, result) {
-      if (!error) {
-        resolve(result);
-      }
-    })
-  })
+function getDataPromiseWithTwoArgs(method, arg1, arg2) {
+	return new Promise(function (resolve, reject) {
+		method(arg1, arg2).call({ from: account }, function (error, result) {
+			console.log('Called method with 2 args')
+			if (!error) {
+				resolve(result);
+			} else {
+				reject(error)
+			}
+		})
+	})
 }
 
 function getBalancePromise(addr) {
-  return new Promise(function(resolve, reject) {
+	return new Promise(function (resolve, reject) {
 
-    web3.eth.getBalance(addr, function(error, result) {
-      if (!error) {
-        resolve(result);
-      }
-    })
-  })
+		window.web3.eth.getBalance(addr, function (error, result) {
+			if (!error) {
+				resolve(result);
+			}
+		})
+	})
 }
 
-function getDataNum(varname, divtag) {
-  varname.call(function(error, result) {
-    if (!error) {
-      $(divtag).html(result.toNumber());
-    } else {
-      console.log(error);
-    }
-  })
+function getDataNum(method, divtag) {
+	method().call({ from: account }, function (error, result) {
+		if (!error) {
+			$(divtag).html(result.toNumber());
+		} else {
+			console.log(error);
+		}
+	})
 }
 
-function getDataStr(varname, divtag) {
-  varname.call(function(error, result) {
-    if (!error) {
-      $(divtag).html(result);
-    } else {
-      console.log(error);
-    }
-  })
+function getDataStr(method, divtag) {
+	method().call({ from: account }, function (error, result) {
+		if (!error) {
+			$(divtag).html(result);
+		} else {
+			console.log(error);
+		}
+	})
 }
 
 function setStatus(message) {
-  $("#status").html(message);
+	$("#status").html(message);
 };
 
 
 
 function vote(proposal) {
-  var proposalID = "proposal" + proposal;
-  var proposalOption = $('input:radio[name=' + proposalID + ']:checked').val();
+	var proposalID = "proposal" + proposal;
+	var proposalOption = parseInt($('input:radio[name=' + proposalID + ']:checked').val());
 
-  console.log("Selected proposal NEWTEST =" + proposal);
-	console.log("Selected proposal option =" + proposalOption);
+	console.log("Selected proposal")
+	console.log(proposal);
+	console.log("Selected proposal option")
+	console.log(proposalOption);
 
 	//setStatus("Initiating transaction... (please wait)");
-  myContractInstance.vote(proposal, proposalOption, function(error, result) {
-    if (!error) {
-       getTransactionReceiptMined(result, proposal).then(function(receipt) {
-					//location.reload();
-					//loadPage();
-          
-
-      });
-    }
-  });
+	console.log("Account");
+	console.log(account)
+	myContractInstance.methods.vote(proposal, proposalOption).send({ from: account })
+		.then(tx => {
+			console.log('Tx going!')
+			console.log(tx)
+			getTransactionReceiptMined(tx.transactionHash, proposal).then(function (receipt) {
+				//location.reload();
+				//loadPage();
+			});
+		})
+		.catch(err => {
+			console.log('Error voting')
+			console.error(err)
+		})
 }
 
 
-var loadPage = () => {
-  setTimeout(() => {
-    if (!window.web3 || !window.web3.eth.accounts[0]) {
-      $("#votingcontractcontainer").hide();
-			$("#votingproposalcontainer").hide();
-			$("#closedvotingproposalcontainer").hide();
-      $("#footercontainer").html("<footer class=\"footer\" style=\"position:absolute;\"><div class=\"container\"><p class=\"rights\"><br>2019 Bloxberg Network. All rights reserved.</p><a class=\"logo\" href='/'></a><div class=\"socials\"></div></div></footer>");
-      $("#status").html(`
-       <div>
-         <div class="pane before-error">
-           <h2>Could not connect to Bloxberg</h2>
-           <p>
+var loadPage = async () => {
+	setTimeout(async () => {
+		const accounts = await ethereum.request({ method: 'eth_accounts' });
+		if (!accounts[0]) {
+			setErrorMessage();
+		} else {
+			//initializeContract();
+			account = accounts[0];
+			console.log(account);
+			initializeContract();
 
-             Consider installing <a href=https://metamask.io>MetaMask</a> or another Ethereum client.
+			window.web3.eth.getBalance(account, function (error, result) {
+				if (!error) {
+					console.log(result);
+					$("#cb_balance").html(parseInt(window.web3.utils.fromWei(result, "ether")).toFixed(5));
 
-             If you are using MetaMask, you may need to unlock your account and connect to the Bloxberg network using custom RPC endpoint https://bloxberg.org/eth/. You can also try disabling and re-enabling
-             the MetaMask plugin by going to <a href=chrome://extensions>chrome://extensions</a>.
-           </p>
+				} else {
+					console.error(error);
+				}
+			});
 
-           <p>Please reload this page and try again.</p>
-         </div>
-       </div>
-     `);
-    } else {
-      //initializeContract();
-      account = web3.eth.accounts[0];
-      console.log(account);
-      initializeContract();
-
-      web3.eth.getBalance(account, function(error, result) {
-        if (!error) {
-          console.log(result);
-          $("#cb_balance").html(web3.fromWei(result, "ether").toFixed(5));
-
-        } else {
-          console.error(error);
-        }
-      });
-
-    }
-  }, 500)
+		}
+	}, 500)
 }
 
 // Inital loading of the page
 if (document.readyState !== 'complete') {
-  // Document has not finished loaded yet, load the page when it is complete
-  window.addEventListener('load', async() => {
+	// Document has not finished loaded yet, load the page when it is complete
+	window.addEventListener('load', async () => {
+		console.log('Page loaded')
 		if (window.ethereum) {
-		await ethereum.enable();
-		loadPage();
-		}
-		else if (window.web3) {
-			
-		loadPage();
+			console.log('window.ethereum')
+			await ethereum.enable();
+			window.web3 = new Web3(window.ethereum);
+			loadPage();
 		} else {
-	
-	// Document has finished loaded, load the page
-	$("#votingcontractcontainer").hide();
-	$("#votingproposalcontainer").hide();
-	$("#closedvotingproposalcontainer").hide();
-	$("#footercontainer").html("<footer class=\"footer\" style=\"position:absolute;\"><div class=\"container\"><p class=\"rights\"><br>2019 Bloxberg Network. All rights reserved.</p><a class=\"logo\" href='/'></a><div class=\"socials\"></div></div></footer>");
-	$("#status").html(`
-       <div>
-         <div class="pane before-error">
-           <h2>Could not connect to Bloxberg</h2>
-           <p>
-
-             Consider installing <a href=https://metamask.io>MetaMask</a> or another Ethereum client.
-
-             If you are using MetaMask, you may need to unlock your account and connect to the Bloxberg network using custom RPC endpoint https://bloxberg.org/eth/. You can also try disabling and re-enabling
-             the MetaMask plugin by going to <a href=chrome://extensions>chrome://extensions</a>.
-           </p>
-
-           <p>Please reload this page and try again.</p>
-         </div>
-       </div>
-     `	);
-			}
-		})
-	}
+			console.log('none')
+			// Document has finished loaded, load the page
+			setErrorMessage();
+		}
+	})
+}
 
 
 
 
 function getTransactionReceiptMined(txHash, proposal, interval) {
-  var transactionReceiptAsync;
-  interval = interval ? interval : 500;
-  transactionReceiptAsync = function(txHash, proposal, resolve, reject) {
-    web3.eth.getTransactionReceipt(txHash, (error, receipt) => {
-      if (error) {
-        reject(error);
-      } else {
-        if (receipt == null) {
-          setTimeout(function() {
-            transactionReceiptAsync(txHash, proposal, resolve, reject);
-          }, interval);
-        } else {
-					resolve(receipt);
-        }
-      }
-    });
-  };
-  if (Array.isArray(txHash)) {
-    var promises = [];
-    txHash.forEach(function(oneTxHash) {
-      promises.push(web3.eth.getTransactionReceiptMined(oneTxHash, interval));
-    });
-    return Promise.all(promises);
-  } else {
+	var transactionReceiptAsync;
+	interval = interval ? interval : 500;
+	transactionReceiptAsync = function (txHash, proposal, resolve, reject) {
+		window.web3.eth.getTransactionReceipt(txHash, (error, receipt) => {
+			if (error) {
+				Promise.reject(error);
+			} else {
+				if (receipt == null) {
+					setTimeout(function () {
+						transactionReceiptAsync(txHash, proposal, resolve, reject);
+					}, interval);
+				} else {
+					Promise.resolve(receipt);
+				}
+			}
+		});
+	};
+	if (Array.isArray(txHash)) {
+		var promises = [];
+		txHash.forEach(function (oneTxHash) {
+			promises.push(window.web3.eth.getTransactionReceipt(oneTxHash, interval));
+		});
+		return Promise.all(promises);
+	} else {
 
-    return new Promise(function(resolve, reject) {
-      transactionReceiptAsync(txHash, resolve, reject);
-    });
-  }
+		return new Promise(function (resolve, reject) {
+			transactionReceiptAsync(txHash, resolve, reject);
+		});
+	}
 };
 
 
 function timeConverter(UNIX_timestamp) {
-  var a = new Date(UNIX_timestamp * 1000);
-  var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-  var year = a.getFullYear();
-  var month = months[a.getMonth()];
-  var date = a.getDate();
-  var hour = a.getHours();
-  var min = a.getMinutes();
-  var sec = a.getSeconds();
-  var time = month + ' ' + date + ', ' + year + ' at ' + hour + ':' + min + ':' + sec;
-  return time;
+	var a = new Date(UNIX_timestamp * 1000);
+	var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+	var year = a.getFullYear();
+	var month = months[a.getMonth()];
+	var date = a.getDate();
+	var hour = a.getHours();
+	var min = a.getMinutes();
+	var sec = a.getSeconds();
+	var time = month + ' ' + date + ', ' + year + ' at ' + hour + ':' + min + ':' + sec;
+	return time;
+}
+
+function setErrorMessage() {
+	$("#votingcontractcontainer").hide();
+	$("#votingproposalcontainer").hide();
+	$("#closedvotingproposalcontainer").hide();
+	$("#footercontainer").html("<footer class=\"footer\" style=\"position:absolute;\"><div class=\"container\"><p class=\"rights\"><br>2019 Bloxberg Network. All rights reserved.</p><a class=\"logo\" href='/'></a><div class=\"socials\"></div></div></footer>");
+	$("#status").html(`
+	<div>
+		<div class="pane before-error">
+			<h2>Could not connect to Bloxberg</h2>
+			<p>
+
+				Consider installing <a href=https://metamask.io>MetaMask</a> or another Ethereum client.
+
+				If you are using MetaMask, you may need to unlock your account and connect to the Bloxberg network using custom RPC endpoint https://bloxberg.org/eth/. You can also try disabling and re-enabling
+				the MetaMask plugin by going to <a href=chrome://extensions>chrome://extensions</a>.
+			</p>
+
+			<p>Please reload this page and try again.</p>
+		</div>
+	</div>
+`);
 }

--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@
     <!-- Latest compiled and minified JavaScript -->
     <script src="https://code.jquery.com/jquery-3.0.0-beta1.js"></script>
     <script type="text/javascript" src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js"></script>
-
+    <script src="https://cdn.jsdelivr.net/npm/web3@latest/dist/web3.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Since Metamask is no longer injecting window.web3 as provider the code
is updated accordingly. We use web3.js as convenience library for
instantiating contracts and interacting with them.

Even though some
methods are similar, most of the code needs refactoring for how to call
the contract methods and for the returned values. Current version of
web3.js (+v1.2) mostly returns String values compared to the outdated
injected web3 (v0.20).

ES6 syntax is used throughout the updated code as users of the dApp are
expected to have Metamask installed, which is available for Chrome and
Firefox. Both browsers support ES6 syntax since around 2014 releases.